### PR TITLE
Fix git repo URL for npmjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "frontend/javascript/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/whitefusiohq/bulmatown.git"
+    "url": "https://github.com/whitefusionhq/bulmatown.git"
   },
   "author": "Jared White <jared@whitefusion.studio>",
   "homepage": "https://www.bridgetownrb.com",


### PR DESCRIPTION
Minor typo fix for the URL. This currently breaks when anyone is trying to access github link from npmjs page. 